### PR TITLE
add Spark 3.5 on JDK 17

### DIFF
--- a/.github/workflows/dockerhub_ci.yml
+++ b/.github/workflows/dockerhub_ci.yml
@@ -22,7 +22,13 @@ jobs:
     strategy:
       matrix:
         # Specify which tags to build
-        DOCKER_TAG: ["3.4.0,3.4,latest", "3.3.2,3.3", "3.1.3,3.1", "3.0.3,3.0", "2.4.8,2.4"]
+        DOCKER_TAG:
+          - "3.5.3,3.5,latest"
+          - "3.4.4,3.4"
+          - "3.3.4,3.3"
+          - "3.1.3,3.1"
+          - "3.0.3,3.0"
+          - "2.4.8,2.4"
 
     timeout-minutes: 30
     steps:
@@ -37,7 +43,10 @@ jobs:
             # Manipulate DOCKER_TAG to create build args
             SPARK_MAJOR_VERSION=${DOCKER_TAG:0:1}
             SPARK_MAJOR_MINOR_VERSION=${DOCKER_TAG:0:3}
-            if [[ ${SPARK_MAJOR_MINOR_VERSION} = "3.3" || ${SPARK_MAJOR_MINOR_VERSION} = "3.4" || ${DOCKER_TAG} == "latest" ]]; then
+            if [[ ${SPARK_MAJOR_MINOR_VERSION} = "3.5" || ${DOCKER_TAG} == "latest" ]]; then
+                OPENJDK_VERSION=17
+                HADOOP_VERSION=3
+            elif [[ ${SPARK_MAJOR_MINOR_VERSION} = "3.3" || ${SPARK_MAJOR_MINOR_VERSION} = "3.4" ]]; then
                 OPENJDK_VERSION=11
                 HADOOP_VERSION=3
             elif [ ${SPARK_MAJOR_VERSION} = "3" ]; then
@@ -97,8 +106,8 @@ jobs:
             IMAGE_NAME: ${{ steps.prep.outputs.image_name }}
         run: |
             if [[ -f "docker-compose.test.yml" ]]; then
-                docker-compose --file docker-compose.test.yml build
-                docker-compose --file docker-compose.test.yml run sut
+                docker compose --file docker-compose.test.yml build
+                docker compose --file docker-compose.test.yml run sut
             fi
 
       - name: Login to DockerHub

--- a/.github/workflows/dockerhub_ci.yml
+++ b/.github/workflows/dockerhub_ci.yml
@@ -66,19 +66,19 @@ jobs:
             BUILD_ARGS="${BUILD_ARGS//$'\n'/'%0A'}"
             BUILD_ARGS="${BUILD_ARGS//$'\r'/'%0D'}"
 
-            echo "::set-output name=build_args::$BUILD_ARGS"
+            echo "build_args=${BUILD_ARGS}" >> $GITHUB_OUTPUT
 
       - name: Prepare
         id: prep
         run: |
             DOCKER_TAG="${{ matrix.DOCKER_TAG }}"
             DOCKER_IMAGE_NAME="$DOCKER_REPO:${DOCKER_TAG%%,*}"
-            echo ::set-output name=image_name::${DOCKER_IMAGE_NAME}
+            echo "image_name=${DOCKER_IMAGE_NAME}" >> $GITHUB_OUTPUT
             
             TAGS="$DOCKER_REPO:${DOCKER_TAG//,/,$DOCKER_REPO:}"
-            echo ::set-output name=tags::${TAGS}
+            echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
-            echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ LABEL org.label-schema.name="Apache Spark ${SPARK_VERSION}" \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$SPARK_VERSION      
       
-ENV SPARK_HOME /usr/spark
+ENV SPARK_HOME=/usr/spark
 ENV PATH="/usr/spark/bin:/usr/spark/sbin:${PATH}"
   
 RUN apt-get update && \
-    apt-get install -y wget netcat procps libpostgresql-jdbc-java && \
+    apt-get install -y wget netcat-openbsd procps libpostgresql-jdbc-java && \
     wget -q "http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" && \
     tar xzf "spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" && \
     rm "spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" && \


### PR DESCRIPTION
- Adds Spark 3.5 on JDK 17
- The `netcat` package has been split/renamed
- Fix deprecation in Dockerfile syntax (`ENV` without `=`)
- Separate `docker-compose` command no longer available in GHA runner
- Refresh deprecated `set-output` syntax in GHA workflow